### PR TITLE
Adapt to renaming of MakeReadOnly->MakeReadOnlyObj

### DIFF
--- a/gap/znode.g
+++ b/gap/znode.g
@@ -213,7 +213,7 @@ ZResponse := function()
   response := CreateSyncVar();
   return `rec(
     put := function(result)
-      SyncWrite(response, MakeReadOnly(result));
+      SyncWrite(response, MakeReadOnlyObj(result));
     end,
     get := -> SyncRead(response),
     test := -> SyncIsBound(response),


### PR DESCRIPTION
This adapts `ZeroMQInterface` to the changes in https://github.com/gap-system/gap/pull/1870