### PR TITLE
Use TNAM_OBJ instead of accessing InfoBags directly

### DIFF
--- a/src/zmqgap.c
+++ b/src/zmqgap.c
@@ -53,7 +53,7 @@ static void *ZmqContext;
 static void BadArgType(Obj obj, char *fname, int pos, char *expected) {
   char buf[1024];
   sprintf(buf, "Bad argument #%d of %s, expected %s, got %s",
-    pos, fname, expected, InfoBags[TNUM_OBJ(obj)].name);
+    pos, fname, expected, TNAM_OBJ(obj));
   ErrorQuit("%s", (Int) buf, 0L);
 }
 


### PR DESCRIPTION
Would be great if a release could be made with this and the other changes since 0.10.

(I could also take care of that, if desired, resp. would do that if this package had "The GAP team" as package maintainer -- but for now, I'll assume that @markuspf prefers to maintain it by himself)