### PR TITLE
Rename SynchronizationFamily to ZmqSynchronizationFamily

### DIFF
--- a/gap/zmq.g
+++ b/gap/zmq.g
@@ -10,10 +10,10 @@
 ##
 
 
-BindGlobal("SynchronizationFamily",
-        NewFamily("SynchronizationFamily", IsObject));
+BindGlobal("ZmqSynchronizationFamily",
+        NewFamily("ZmqSynchronizationFamily", IsObject));
 DeclareFilter("IsZmqSocket", IsObject and IsInternalRep);
-BindGlobal("TYPE_ZMQ_SOCKET", NewType(SynchronizationFamily, IsZmqSocket));
+BindGlobal("TYPE_ZMQ_SOCKET", NewType(ZmqSynchronizationFamily, IsZmqSocket));
 
 BindGlobal("ZmqAttach", function(socket, addr)
   if addr <> "" and addr[1] = '+' then

--- a/gap/zmq.g
+++ b/gap/zmq.g
@@ -10,8 +10,6 @@
 ##
 
 
-BindGlobal("ZmqSynchronizationFamily",
-        NewFamily("ZmqSynchronizationFamily", IsObject));
 DeclareFilter("IsZmqSocket", IsObject and IsInternalRep);
 BindGlobal("TYPE_ZMQ_SOCKET", NewType(NewFamily("ZmqFamily", IsObject), IsZmqSocket));
 

--- a/gap/zmq.g
+++ b/gap/zmq.g
@@ -13,7 +13,7 @@
 BindGlobal("ZmqSynchronizationFamily",
         NewFamily("ZmqSynchronizationFamily", IsObject));
 DeclareFilter("IsZmqSocket", IsObject and IsInternalRep);
-BindGlobal("TYPE_ZMQ_SOCKET", NewType(ZmqSynchronizationFamily, IsZmqSocket));
+BindGlobal("TYPE_ZMQ_SOCKET", NewType(NewFamily("ZmqFamily", IsObject), IsZmqSocket));
 
 BindGlobal("ZmqAttach", function(socket, addr)
   if addr <> "" and addr[1] = '+' then


### PR DESCRIPTION
This is needed because SynchronizationFamily is defined in GAP in `lib/hpc/thread.g`.

I have checked that it's not used elsewhere, so renaming should be harmless.