### PR TITLE
if no path for zmq is given, check for macos homebrew

### DIFF
--- a/doc/intro.xml
+++ b/doc/intro.xml
@@ -36,7 +36,7 @@ To compile this package, inside its root directory run:
 </Log>
 Or
 <Log>
-> ./configure --with-zmq=<path-to-your-zeromq>
+> ./configure --with-zmq=path-to-your-zeromq
 > make
 </Log>
 to specify where &ZeroMQ; is located in you system.

--- a/doc/intro.xml
+++ b/doc/intro.xml
@@ -34,7 +34,12 @@ To compile this package, inside its root directory run:
 > ./configure
 > make
 </Log>
-
+Or
+<Log>
+> ./configure --with-zmq=<path-to-your-zeromq>
+> make
+</Log>
+to specify where &ZeroMQ; is located in you system.
 </Section>
 
 <Section Label="feedback">

--- a/m4/ax_zmq.m4
+++ b/m4/ax_zmq.m4
@@ -43,10 +43,9 @@ AC_DEFUN([AX_ZMQ], [
     AS_IF([command -v brew >/dev/null 2>&1],[
         AC_MSG_NOTICE([BREW detected])
         with_zmq=$(brew --prefix)
+        ZMQ_LDFLAGS="-L${with_zmq}/opt/zeromq/lib"
+        ZMQ_CPPFLAGS="-I${with_zmq}/opt/zeromq/include"    
         ])
-
-    ZMQ_LDFLAGS="-L${with_zmq}/opt/zeromq/lib"
-    ZMQ_CPPFLAGS="-I${with_zmq}/opt/zeromq/include"    
     ])
 
     HAVE_ZMQ=0

--- a/m4/ax_zmq.m4
+++ b/m4/ax_zmq.m4
@@ -37,6 +37,16 @@ AC_DEFUN([AX_ZMQ], [
     AC_ARG_WITH([zmq], [AS_HELP_STRING([--with-zmq=<prefix>],[ZMQ prefix directory])], [
         ZMQ_LDFLAGS="-L${with_zmq}/lib"
         ZMQ_CPPFLAGS="-I${with_zmq}/include"
+    ],
+    [
+    # no --with-zmq given, so we try to check if hombrew (macos) is present
+    AS_IF([command -v brew >/dev/null 2>&1],[
+        AC_MSG_NOTICE([BREW detected])
+        with_zmq=$(brew --prefix)
+        ])
+
+    ZMQ_LDFLAGS="-L${with_zmq}/opt/zeromq/lib"
+    ZMQ_CPPFLAGS="-I${with_zmq}/opt/zeromq/include"    
     ])
 
     HAVE_ZMQ=0

--- a/m4/ax_zmq.m4
+++ b/m4/ax_zmq.m4
@@ -39,12 +39,12 @@ AC_DEFUN([AX_ZMQ], [
         ZMQ_CPPFLAGS="-I${with_zmq}/include"
     ],
     [
-    # no --with-zmq given, so we try to check if hombrew (macos) is present
-    AS_IF([command -v brew >/dev/null 2>&1],[
-        AC_MSG_NOTICE([BREW detected])
-        with_zmq=$(brew --prefix)
-        ZMQ_LDFLAGS="-L${with_zmq}/opt/zeromq/lib"
-        ZMQ_CPPFLAGS="-I${with_zmq}/opt/zeromq/include"    
+    # no --with-zmq given, so we try to check if hombrew zeromq (macos) is present
+    AS_IF([command -v brew --prefix zeromq >/dev/null 2>&1],[
+        AC_MSG_NOTICE([BREW zeromq detected])
+        with_zmq=$(brew --prefix zeromq)
+        ZMQ_LDFLAGS="-L${with_zmq}/lib"
+        ZMQ_CPPFLAGS="-I${with_zmq}/include"    
         ])
     ])
 


### PR DESCRIPTION
if no option --with-zmq=<prefix> is given, it checks for homebrew and uses $(brew --prefix zeromq) as prefix.