### PR TITLE
Replace compiled.h by gap_all.h

### DIFF
--- a/src/zmqgap.c
+++ b/src/zmqgap.c
@@ -11,7 +11,7 @@
 ##  This file was originally contributed to HPC-GAP by Reimer Behrends
 ##
 */
-#include "compiled.h" // GAP headers
+#include "gap_all.h" // GAP headers
 #include "zmq.h"
 
 #include <stdlib.h>


### PR DESCRIPTION
No functional change for this package but makes it future-proof.
