### PR TITLE
Fix anonymous function definitions

### DIFF
--- a/gap/znode.g
+++ b/gap/znode.g
@@ -215,8 +215,8 @@ ZResponse := function()
     put := function(result)
       SyncWrite(response, MakeReadOnlyObj(result));
     end,
-    get := -> SyncRead(response),
-    test := -> SyncIsBound(response),
+    get := {} -> SyncRead(response),
+    test := {} -> SyncIsBound(response),
   ));
 end;
 


### PR DESCRIPTION
This PR fixes an issue with the `get` and `test` functions. When defining an anonymous nullary function, the proper syntax is `{} -> foo;` to indicate that no arguments are passed.