### PR TITLE
Update `PackageInfo.g` and CI suite

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -19,41 +19,33 @@ concurrency:
 jobs:
   # The CI test job
   test:
-    name: ${{ matrix.gap-branch }} ${{ matrix.os }}
+    name: ${{ matrix.gap-version }} ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        gap-branch:
-          - master
-          - stable-4.15
-          - stable-4.14
-          - stable-4.13
-          - stable-4.12
+        gap-version:
+          - 'devel'
+          - '4.15'
+          - '4.14'
+          - '4.13'
+          - '4.12'
         os: [ubuntu-latest]
         include:
-          - gap-branch: master
+          - gap-version: 'devel'
             os: macos-latest
 
     steps:
       - uses: actions/checkout@v6
-      - name: 'Install additional dependencies'
-        run: |
-          if [ "$RUNNER_OS" == "macOS" ]; then
-            brew install zmq
-          else
-            sudo apt-get update
-            sudo apt-get install libczmq-dev
-          fi
-      - uses: gap-actions/setup-gap@v2
+      - uses: gap-actions/setup-gap@v3
         with:
-          GAPBRANCH: ${{ matrix.gap-branch }}
-      - uses: gap-actions/build-pkg@v1
-      - uses: gap-actions/run-pkg-tests@v3
-      - uses: gap-actions/run-pkg-tests@v3
+          gap-branch: ${{ matrix.gap-version }}
+      - uses: gap-actions/build-pkg@v3
+      - uses: gap-actions/run-pkg-tests@v4
+      - uses: gap-actions/run-pkg-tests@v4
         with:
-          only-needed: true
-      - uses: gap-actions/process-coverage@v2
-      - uses: codecov/codecov-action@v5
+          mode: onlyneeded
+      - uses: gap-actions/process-coverage@v3
+      - uses: codecov/codecov-action@v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -95,6 +95,7 @@ Dependencies := rec(
   GAP := ">= 4.12",
   NeededOtherPackages := [ [ "GAPDoc", ">= 1.6.1" ] ],
   SuggestedOtherPackages := [ ],
+  NeededSystemPackages := rec( Ubuntu := [["libzmq3-dev"]], Homebrew := [["zmq"]] ),
   ExternalConditions := [ ],
 ),
 


### PR DESCRIPTION
This PR updates all actions used in the CI workflow to the latest version, and makes use of the new `Dependencies.NeededSystemPackages` field in `PackageInfo.g` to simplify the CI workflow(s).

Remarks:
- I replaced `libczmq-dev` by `libzmq3-dev`, as the latter is smaller and suffices to test this package. If that's wrong, please change it back.
- The `Dependencies.ExternalConditions` is empty. Since this package relies on external software, it probably shouldn't be.

